### PR TITLE
Fix bug "sh: autom4te: command not found"

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -7,7 +7,7 @@ class EmacsMac < Formula
   url 'https://github.com/railwaycat/emacs-mac-port.git', :using => :git, :tag => 'v4.5'
   version 'emacs-24.3-mac-4.5'
 
-  depends_on 'automake' => :build
+  depends_on 'automake'
   depends_on 'pkg-config' => :build
 
   option 'with-dbus', 'Build with d-bus support'


### PR DESCRIPTION
When building under Mavericks, user gets error:
sh: autom4te: command not found
although the sources compile perfectly fine by hand.
This patch fixes this bug (maybe the same needs to be done for 'pkg-config').
