### PR TITLE
Add cask

### DIFF
--- a/Casks/emacs-mac.rb
+++ b/Casks/emacs-mac.rb
@@ -1,0 +1,10 @@
+class EmacsMac < Cask
+  version 'emacs-24.3-mac-4.8'
+
+  sha256 '75870d4862d4ea8b8e2e187024961e9f01d5aed2b42657d9851b9d9194b057c9'
+
+  url 'https://dl.dropboxusercontent.com/s/1jpyiifhgjw0flg/emacs-mac-port-24.3-mac-4.8.zip'
+  homepage 'http://www.gnu.org/software/emacs/'
+
+  link 'Emacs.app'
+end

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Note: If you want info files from emacs been installed under `{brew --prefix}/sh
     export INFOPATH='/usr/local/share/info:/usr/share/info'
 ```
 
+If you use [cask](http://caskroom.io/), run `brew cask install emacs-mac`.
+
 - Disable:
 ```
     brew untap railwaycat/emacsmacport


### PR DESCRIPTION
Maybe someone like me do not like building Emacs on Mac. Cask just download and install Emacs mac port.

I put `Casks` and `Formula` in one tap, maybe not a good idea but convenient  for me. 
