### PR TITLE
Formula cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@
     brew install emacs-mac
 ```
 
-Note: If you want info files from emacs been installed under `{brew --prefix}/share/info`, an enviroment variable `HOMEBREW_KEEP_INFO` set to `1` is needed before install. Prepend `{brew --prefix}/share/info` to your `INFOPATH` is also suggested to access these info files. Read more: `man brew`. For example:
+Note: Prepend `{brew --prefix}/share/info` to your `INFOPATH` is suggested to access the info files. For example:
 
 
 ```
-    export HOMEBREW_KEEP_INFO=1
     export INFOPATH='/usr/local/share/info:/usr/share/info'
 ```
 


### PR DESCRIPTION
- Based on feedback from `brew audit emacs-mac --strict`.
- Removed info about `HOMEBREW_KEEP_INFO` which has been unnecessary
  for a year, see https://github.com/Homebrew/homebrew/issues/26659.
- Fixed build time dependencies (https://github.com/railwaycat/emacs-mac-port/issues/36 / #1) - it missed a `depends_on :autoconf`.