### PR TITLE
Fix Markdown formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,28 @@
 # Homebrew-emacsmacport
 ### Usage
-- Enable:
+##### Enable:
 ```
-    brew tap railwaycat/emacsmacport
-```
-
-- Install:
-```
-    brew install emacs-mac
+brew tap railwaycat/emacsmacport
 ```
 
-Note: Prepend `{brew --prefix}/share/info` to your `INFOPATH` is suggested to access the info files. For example:
+##### Install:
+```
+brew install emacs-mac
+```
 
+Note: Prepending `{brew --prefix}/share/info` to your `INFOPATH` is suggested to access the info files. For example:
 
 ```
-    export INFOPATH='/usr/local/share/info:/usr/share/info'
+export INFOPATH='/usr/local/share/info:/usr/share/info'
 ```
 
 If you use [cask](http://caskroom.io/), run:
 
 ```
-    brew cask install emacs-mac
+brew cask install emacs-mac
 ```
 
-- Disable:
+##### Disable:
 ```
-    brew untap railwaycat/emacsmacport
+brew untap railwaycat/emacsmacport
 ```


### PR DESCRIPTION
- remove extra indentation in front of code (you need either triple-backtick *or* four-space indent, not both)
- change list items to headings, rather than fixing the semantics by indenting all text under list items

and fix grammar of “prepending”