### PR TITLE
Fix tap name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This build has *many* features, a great number of which are particularly helpful
 ### Homebrew ###
 If you'd like to install with Homebrew, please
 
-`$ brew tap railwaycat/emacsmacport`
+`$ brew tap railwaycat/homebrew-emacsmacport`
 
 and then
  


### PR DESCRIPTION
This typo had me scratching my head for a good 15 minutes until I realized the repository name wasn't the same as this `brew tap` command.
