### PR TITLE
Remove the version hash from Cask.

### DIFF
--- a/Casks/emacs-mac.rb
+++ b/Casks/emacs-mac.rb
@@ -1,4 +1,4 @@
-cask :v1 => 'emacs-mac' do
+cask 'emacs-mac' do
   version 'emacs-24.5-z-mac-5.15'
 
   sha256 '66571ecd8ea14c6e8ce63d1d60fdbaff66f81e2a3ae45c45102a0fb9e5d3ada6'


### PR DESCRIPTION
Hi,

Seems like Cask has recently [deprecated DSL version](https://github.com/caskroom/homebrew-cask/issues/15782). Leaving the `:v1` now make Cask raise this error:

```
Error: Cask 'emacs-mac' definition is invalid: Bad header line: '{:v1=>"emacs-mac"}' does not match file name
```

I've fixed this by removing the `:v1` from the Cask DSL.
Thanks!