### PR TITLE
Add --with-modules option

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -12,6 +12,7 @@ class EmacsMac < Formula
   depends_on "pkg-config" => :build
 
   option "with-dbus", "Build with d-bus support"
+  option "with-modules", "Build with dynamic modules support"
   option "with-xml2", "Build with libxml2 support"
   option "with-ctags", "Don't remove the ctags executable that emacs provides"
   option "with-official-icon", "Using offical Emacs icon"
@@ -93,6 +94,8 @@ class EmacsMac < Formula
       "--with-mac",
       "--enable-mac-app=#{prefix}",
     ]
+
+    args << "--with-modules" if build.with? "modules"
 
     # icons
     icons_dir = "./mac/Emacs.app/Contents/Resources"


### PR DESCRIPTION
This commit is for using new configure option '--with-modules' was added at Emacs 25. This option builds Emacs with support for loading dynamic modules.