### PR TITLE
emacs-mac: audit, make icons resources with sha256

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -1,15 +1,11 @@
 class EmacsMac < Formula
+  desc "YAMAMOTO Mitsuharu's native Mac port of GNU Emacs"
   homepage "https://www.gnu.org/software/emacs/"
-
-  head "https://bitbucket.org/mituharu/emacs-mac.git", :branch => "work"
-
   url "https://bitbucket.org/mituharu/emacs-mac/get/emacs-25.1-mac-6.0.tar.gz"
-  sha256 "5152b6cc403914c6333a677faf28247a98c1126c95382665b228113840ac3dfe"
   version "emacs-25.1-z-mac-6.0"
+  sha256 "5152b6cc403914c6333a677faf28247a98c1126c95382665b228113840ac3dfe"
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "pkg-config" => :build
+  head "https://bitbucket.org/mituharu/emacs-mac.git", branch: "work"
 
   option "with-dbus", "Build with d-bus support"
   option "with-modules", "Build with dynamic modules support"
@@ -21,23 +17,23 @@ class EmacsMac < Formula
 
   # Update list from
   # https://raw.githubusercontent.com/emacsfodder/emacs-icons-project/master/icons.json
-  @@emacs_icons_project_icons = [
-    "EmacsIcon1",
-    "EmacsIcon2",
-    "EmacsIcon3",
-    "EmacsIcon4",
-    "EmacsIcon5",
-    "EmacsIcon6",
-    "EmacsIcon7",
-    "EmacsIcon8",
-    "EmacsIcon9",
-    "emacs-card-blue-deep",
-    "emacs-card-british-racing-green",
-    "emacs-card-carmine",
-    "emacs-card-green"
-  ]
+  emacs_icons_project_icons = {
+    "EmacsIcon1" => "50dbaf2f6d67d7050d63d987fe3743156b44556ab42e6d9eee92248c56011bd0",
+    "EmacsIcon2" => "8d63589b0302a67f13ab94b91683a8ad7c2b9e880eabe008056a246a22592963",
+    "EmacsIcon3" => "80dd2a4776739a081e0a42008e8444c729d41ba876b19fa9d33fde98ee3e0ebf",
+    "EmacsIcon4" => "8ce646ca895abe7f45029f8ff8f5eac7ab76713203e246b70dea1b8a21a6c135",
+    "EmacsIcon5" => "ca415df7ad60b0dc495626b0593d3e975b5f24397ad0f3d802455c3f8a3bd778",
+    "EmacsIcon6" => "12a1999eb006abac11535b7fe4299ebb3c8e468360faf074eb8f0e5dec1ac6b0",
+    "EmacsIcon7" => "f5067132ea12b253fb4a3ea924c75352af28793dcf40b3063bea01af9b2bd78c",
+    "EmacsIcon8" => "d330b15cec1bcdfb8a1e8f8913d8680f5328d59486596fc0a9439b54eba340a0",
+    "EmacsIcon9" => "f58f46e5ef109fff8adb963a97aea4d1b99ca09265597f07ee95bf9d1ed4472e",
+    "emacs-card-blue-deep" => "6bdb17418d2c620cf4132835cfa18dcc459a7df6ce51c922cece3c7782b3b0f9",
+    "emacs-card-british-racing-green" => "ddf0dff6a958e3b6b74e6371f1a68c2223b21e75200be6b4ac6f0bd94b83e1a5",
+    "emacs-card-carmine" => "4d34f2f1ce397d899c2c302f2ada917badde049c36123579dd6bb99b73ebd7f9",
+    "emacs-card-green" => "f94ade7686418073f04b73937f34a1108786400527ed109af822d61b303048f7",
+  }
 
-  @@emacs_icons_project_icons.each do |icon|
+  emacs_icons_project_icons.keys.each do |icon|
     option "with-emacs-icons-project-#{icon}", "Using Emacs icon project #{icon}"
   end
 
@@ -45,11 +41,75 @@ class EmacsMac < Formula
   deprecated_option "icon-official" => "with-official-icon"
   deprecated_option "icon-modern" => "with-modern-icon"
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "pkg-config" => :build
+
   depends_on "d-bus" if build.with? "dbus"
   depends_on "glib" => :optional
   depends_on "gnutls" => :optional
   depends_on "imagemagick" => :optional
   depends_on "libxml2" if build.with? "xml2"
+
+  emacs_icons_project_icons.each do |icon, sha|
+    resource "emacs-icons-project-#{icon}" do
+      url "https://raw.githubusercontent.com/emacsfodder/emacs-icons-project/master/#{icon}.icns"
+      sha256 sha
+    end
+  end
+
+  resource "official-icon" do
+    url "https://s3.amazonaws.com/emacs-mac-port/Emacs25.icns"
+    sha256 "853125bc2fa0148b8e611f9b96f61031085a3c367661a9357febf4976dc4aa3e"
+  end
+
+  resource "modern-icon" do
+    url "https://s3.amazonaws.com/emacs-mac-port/Emacs.icns.modern"
+    sha256 "eb819de2380d3e473329a4a5813fa1b4912ec284146c94f28bd24fbb79f8b2c5"
+  end
+
+  resource "spacemacs-icon" do
+    url "https://github.com/nashamri/spacemacs-logo/blob/master/spacemacs.icns?raw=true"
+    sha256 "b3db8b7cfa4bc5bce24bc4dc1ede3b752c7186c7b54c09994eab5ec4eaa48900"
+  end
+
+  def install
+    args = [
+      "--enable-locallisppath=#{HOMEBREW_PREFIX}/share/emacs/site-lisp",
+      "--infodir=#{info}/emacs",
+      "--prefix=#{prefix}",
+      "--with-mac",
+      "--enable-mac-app=#{prefix}",
+    ]
+    args << "--with-modules" if build.with? "modules"
+
+    icons_dir = buildpath/"mac/Emacs.app/Contents/Resources"
+
+    (%w[EmacsIcon1 EmacsIcon2 EmacsIcon3 EmacsIcon4
+        EmacsIcon5 EmacsIcon6 EmacsIcon7 EmacsIcon8
+        EmacsIcon9 emacs-card-blue-deep emacs-card-british-racing-green
+        emacs-card-carmine emacs-card-green].map { |i| "emacs-icons-project-#{i}" } +
+     %w[official-icon modern-icon spacemacs-icon]).each do |icon|
+      next if build.without? icon
+
+      rm "#{icons_dir}/Emacs.icns"
+      resource(icon).stage do
+        icons_dir.install Dir["*.icns*"].first => "Emacs.icns"
+      end
+    end
+
+    system "./autogen.sh"
+    system "./configure", *args
+    system "make"
+    system "make", "install"
+
+    # Follow Homebrew and don't install ctags from Emacs. This allows Vim
+    # and Emacs and exuberant ctags to play together without violence.
+    if build.without? "ctags"
+      (bin/"ctags").unlink
+      (share/man/man1/"ctags.1.gz").unlink
+    end
+  end
 
   def caveats
     <<-EOS.undent
@@ -73,65 +133,7 @@ class EmacsMac < Formula
     EOS
   end
 
-  # Follow Homebrew and don't install ctags from Emacs. This allows Vim
-  # and Emacs and exuberant ctags to play together without violence.
-  def do_not_install_ctags
-    if build.without? "ctags"
-      (bin/"ctags").unlink
-      (share/man/man1/"ctags.1.gz").unlink
-    end
-  end
-
-  def emacs_icons_project_uri(icon)
-    "https://raw.githubusercontent.com/emacsfodder/emacs-icons-project/master/#{icon}.icns"
-  end
-
-  def install
-    args = [
-      "--enable-locallisppath=#{HOMEBREW_PREFIX}/share/emacs/site-lisp",
-      "--infodir=#{info}/emacs",
-      "--prefix=#{prefix}",
-      "--with-mac",
-      "--enable-mac-app=#{prefix}",
-    ]
-
-    args << "--with-modules" if build.with? "modules"
-
-    # icons
-    icons_dir = "./mac/Emacs.app/Contents/Resources"
-    official_icons = "https://s3.amazonaws.com/emacs-mac-port/Emacs25.icns"
-    modern_icons = "https://s3.amazonaws.com/emacs-mac-port/Emacs.icns.modern"
-    spacemacs_icons = "https://github.com/nashamri/spacemacs-logo/blob/master/spacemacs.icns?raw=true"
-
-    @@emacs_icons_project_icons.each do |icon|
-      if build.with? "emacs-icons-project-#{icon}"
-        rm "#{icons_dir}/Emacs.icns"
-        curl emacs_icons_project_uri(icon), "-o", "#{icons_dir}/Emacs.icns"
-      end
-    end
-
-    if build.with? "official-icon"
-      rm "#{icons_dir}/Emacs.icns"
-      curl "#{official_icons}", "-o", "#{icons_dir}/Emacs.icns"
-    elsif build.with? "modern-icon"
-      rm "#{icons_dir}/Emacs.icns"
-      curl "#{modern_icons}", "-o", "#{icons_dir}/Emacs.icns"
-    elsif build.with? "spacemacs-icon"
-      rm "#{icons_dir}/Emacs.icns"
-      curl "-L", "#{spacemacs_icons}", "-o", "#{icons_dir}/Emacs.icns"
-    end
-
-    # build
-    system "./autogen.sh"
-    system "./configure", *args
-    system "make"
-    system "make", "install"
-
-    # Don't cause ctags clash.
-    do_not_install_ctags
-  end
-
   test do
-    system "emacs", "--batch"
+    assert_equal "4", shell_output("#{bin}/emacs --batch --eval=\"(print (+ 2 2))\"").strip
   end
 end


### PR DESCRIPTION
I know this is basically a rewrite, so I won't be offended if it's rejected.  But I think it's worth it because it
- updates the formula to pass `brew audit` 
- adds a description
- includes the icons as `resource`s so they can be checksummed and downloaded with `brew fetch`
- makes the test a little better