### PR TITLE
Update to emacs-25.1-mac-6.1

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -1,9 +1,9 @@
 class EmacsMac < Formula
   desc "YAMAMOTO Mitsuharu's native Mac port of GNU Emacs"
   homepage "https://www.gnu.org/software/emacs/"
-  url "https://bitbucket.org/mituharu/emacs-mac/get/emacs-25.1-mac-6.0.tar.gz"
-  version "emacs-25.1-z-mac-6.0"
-  sha256 "5152b6cc403914c6333a677faf28247a98c1126c95382665b228113840ac3dfe"
+  url "https://bitbucket.org/mituharu/emacs-mac/get/emacs-25.1-mac-6.1.tar.gz"
+  version "emacs-25.1-z-mac-6.1"
+  sha256 "3ede57b06a20b361d5ed66d040e3b0adb1a84cbccabb6eaf21e2d8e8398de3b6"
 
   head "https://bitbucket.org/mituharu/emacs-mac.git", branch: "work"
 


### PR DESCRIPTION
sha256 of the gz file
3ede57b06a20b361d5ed66d040e3b0adb1a84cbccabb6eaf21e2d8e8398de3b6

copy paste of the changelog for emacs-25.1-mac-6.1

```
* emacs-25.1-mac-6.1 (2016-10-30)
** Fixed bugs
*** Incremental search with a Japanese text in an empty buffer fails.
Reported by Takaaki Ishikawa.
*** Crash when showing a tooltip on macOS 10.12 if compiled with
enable-checking.
*** Crash with C-x 5 5 2 -> C-x 5 2 -> close the first frame with the
red "x" button on macOS 10.12.
*** Fullscreen transition animation looks awkward on OS X 10.7.
This is a regression introduced in 6.0 as the fix for "fullscreen
frames contain space at the top on OS X 10.10".
*** Proxy icon is sometimes not updated.
*** M-x battery RET does not show battery info on macOS 10.12.
Apply a fix for Bug#24537.
*** Emacs sometimes becomes unresponsive to Dock icon clicks (though
it reacts to Command-Tab) if its frames are completely covered by
other applications for a while on macOS 10.12.
** Improvements
*** Ligature glyph width is adjusted to a multiple of space width for
monospace fonts.
*** Screen update during resize now works on macOS 10.12 if
frame-resize-pixelwise is nil.
*** Character Picker is shown in Touch Bar.
```