### PR TITLE
Install emacs-module.h when built with module support

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -116,6 +116,11 @@ class EmacsMac < Formula
     system "make"
     system "make", "install"
 
+    if build.with? "modules"
+        src_dir = "#{prefix}/src"
+        src_dir.install "src/emacs-module.h"
+    end
+
     # Follow Homebrew and don't install ctags from Emacs. This allows Vim
     # and Emacs and exuberant ctags to play together without violence.
     if build.without? "ctags"


### PR DESCRIPTION
Currently if one installs emacs-mac as 'brew install --with-modules emacs-mac',
dynamic loading of modules will be enabled, but it won't be possible to
actually build modules, because of the missing header dependency.

I've stumbled upon this problem when building https://github.com/akermu/emacs-libvterm against emacs-mac.