### PR TITLE
Add the `plist` block from homebrew-core

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -125,6 +125,25 @@ class EmacsMac < Formula
     end
   end
 
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>Label</key>
+      <string>#{plist_name}</string>
+      <key>ProgramArguments</key>
+      <array>
+        <string>#{opt_bin}/emacs</string>
+        <string>--daemon</string>
+      </array>
+      <key>RunAtLoad</key>
+      <true/>
+    </dict>
+    </plist>
+    EOS
+  end
+
   def caveats
     <<-EOS.undent
       This is YAMAMOTO Mitsuharu's "Mac port" addition to


### PR DESCRIPTION
This allows you to use `brew services` to run Emacs as a daemon.

This is literally just copied and pasted from the homebrew-core Emacs formula.