### PR TITLE
Add ctags binary to casks and add formulae conflicts

### DIFF
--- a/Casks/emacs-mac-spacemacs-icon.rb
+++ b/Casks/emacs-mac-spacemacs-icon.rb
@@ -19,10 +19,15 @@ cask 'emacs-mac-spacemacs-icon' do
   conflicts_with cask: [
                         'emacs',
                         'emacs-mac',
+                      ],
+                 formula: [
+                        'emacs',
+                        'ctags'
                        ]
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs.sh", target: 'emacs'
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ctags"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"

--- a/Casks/emacs-mac.rb
+++ b/Casks/emacs-mac.rb
@@ -19,10 +19,15 @@ cask 'emacs-mac' do
   conflicts_with cask: [
                         'emacs',
                         'emacs-mac-spacemacs-icon',
+                       ],
+                 formula: [
+                        'emacs',
+                        'ctags'
                        ]
 
   app 'Emacs.app'
   binary "#{appdir}/Emacs.app/Contents/MacOS/Emacs.sh", target: 'emacs'
+  binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ctags"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/ebrowse"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/emacsclient"
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"


### PR DESCRIPTION
~This creates links of the embedded binaries in `/usr/local/bin` (`emacs`, `ctags`, `ebrowse`, `emacsclient`, `etags`).~
~This allows the use of these binaries in the terminal.~
~I've also added the `conflicts_with` and `zap trash` section for completeness.~
~I took these changes from the official [emacs cask](https://github.com/caskroom/homebrew-cask/blob/d563f4503855f9736e579127bd284d082d36f099/Casks/emacs.rb).~
Edit 20181003: dc1d2a5ad5c780f837224c621a40fc7f1ef92b7d added most of the original changes of this PR.
This now adds `ctags` from the official [emacs cask](https://github.com/caskroom/homebrew-cask/blob/d563f4503855f9736e579127bd284d082d36f099/Casks/emacs.rb) and declares formulae conflicts.