### PR TITLE
Add a --with-jansson option to build native json.

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -54,6 +54,7 @@ class EmacsMac < Formula
   depends_on "glib" => :optional
   depends_on "imagemagick" => :optional
   depends_on "librsvg" if build.with? "rsvg"
+  depends_on "jansson" => :optional
 
   emacs_icons_project_icons.each do |icon, sha|
     resource "emacs-icons-project-#{icon}" do


### PR DESCRIPTION
Emacs 27 now offers native json support, but it requires the jansson library to build against. Add a --with-jansson option. When combined with --HEAD, this will build a version of emacs with native json support.