### PR TITLE
Update GNU head icon path

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -79,7 +79,7 @@ class EmacsMac < Formula
   end
 
   resource "gnu-head-icon" do
-    url "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/master/icons/heckert_gnu.icns"
+    url "https://raw.githubusercontent.com/d12frosted/homebrew-emacs-plus/master/icons/gnu-head.icns"
     sha256 "b5899aaa3589b54c6f31aa081daf29d303047aa07b5ca1d0fd7f9333a829b6d3"
   end
 


### PR DESCRIPTION
Path to GNU head icon has been changed due to the PR https://github.com/d12frosted/homebrew-emacs-plus/pull/246