### PR TITLE
Adding `doom sync` caveat

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -202,6 +202,9 @@ class EmacsMac < Formula
       Other ways please refer:
         https://github.com/railwaycat/homebrew-emacsmacport/wiki/Alternative-way-of-place-Emacs.app-to-Applications-directory
 
+      If you are using Doom Emacs, be sure to run doom sync:
+        ~/.emacs.d/doom sync
+
       For an Emacs.app CLI starter, see:
         https://gist.github.com/4043945
     EOS


### PR DESCRIPTION
Adding the `doom sync` caveat to the deploy instructions so that users who have an existing Doom Emacs setup avoid error #167.