### PR TITLE
fix doom binary path

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -158,7 +158,7 @@ class EmacsMac < Formula
         https://github.com/railwaycat/homebrew-emacsmacport/wiki/Alternative-way-of-place-Emacs.app-to-Applications-directory
 
       If you are using Doom Emacs, be sure to run doom sync:
-        ~/.emacs.d/doom sync
+        ~/.emacs.d/bin/doom sync
 
       For an Emacs.app CLI starter, see:
         https://gist.github.com/4043945


### PR DESCRIPTION
`doom` binary is nested inside `.emacs.d/bin/` now.