### PR TITLE
update titlebar patch for emacs 28.1/9.0

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -78,8 +78,8 @@ class EmacsMac < Formula
 
   if build.with? "natural-title-bar"
     patch do
-      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/7b3efcb066625f7a3423a229ff1a8d8a53fa6175/patches/emacs-mac-title-bar-8.3.patch"
-      sha256 "21f7fca8d91650bd705c218995084eaa6a8eed9a0c46516299feabee5ecafb63"
+      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/master/patches/emacs-mac-title-bar-9.0.patch"
+      sha256 "4c719da92bf7744bb7931315ddcca78b190d7513adf49f86e7c2ae93dacfc68b"
     end
   end
 

--- a/patches/emacs-mac-title-bar-9.0.patch
+++ b/patches/emacs-mac-title-bar-9.0.patch
@@ -1,0 +1,50 @@
+diff --git a/src/macappkit.m b/src/macappkit.m
+index 16403f9bf5..2118b8bb13 100644
+--- a/src/macappkit.m
++++ b/src/macappkit.m
+@@ -1935,6 +1935,18 @@ - (BOOL)doesHoldQuit
+
+ @implementation EmacsWindow
+
+++ (NSButton *)standardWindowButton:(NSWindowButton)b forStyleMask:(NSWindowStyleMask)styleMask
++{
++
++  NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
++  NSString *hideDocumentIcon = [userDefaults stringForKey: @"HideDocumentIcon"];
++
++  if([hideDocumentIcon isEqualToString: @"YES"] && (b == NSWindowDocumentIconButton || b == NSWindowDocumentVersionsButton)) {
++    return nil;
++  }
++  return [NSWindow standardWindowButton:b forStyleMask:styleMask];
++}
++
+ - (instancetype)initWithContentRect:(NSRect)contentRect
+				styleMask:(NSWindowStyleMask)windowStyle
+					backing:(NSBackingStoreType)bufferingType
+@@ -2495,6 +2507,19 @@ - (void)setupWindow
+   window.contentView = visualEffectView;
+   MRC_RELEASE (visualEffectView);
+   FRAME_BACKGROUND_ALPHA_ENABLED_P (f) = true;
++	NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
++  NSString *transparentTitleBar = [userDefaults stringForKey: @"TransparentTitleBar"];
++
++  if ([transparentTitleBar isEqualToString: @"DARK"]) {
++    window.titlebarAppearsTransparent = true;
++    window.appearance = [NSAppearance appearanceNamed: NSAppearanceNameVibrantDark];
++  }
++
++  if ([transparentTitleBar isEqualToString: @"LIGHT"]) {
++    window.titlebarAppearsTransparent = true;
++    window.appearance = [NSAppearance appearanceNamed: NSAppearanceNameVibrantLight];
++  }
++
+   if (FRAME_MAC_DOUBLE_BUFFERED_P (f))
+     {
+       FRAME_SYNTHETIC_BOLD_WORKAROUND_DISABLED_P (f) = true;
+@@ -6309,6 +6334,7 @@ + (void)initialize
+
+				if ([defaults objectForKey:@"ApplePressAndHoldEnabled"] == nil)
+		[defaults registerDefaults:@{@"ApplePressAndHoldEnabled" : @"NO"}];
++	[NSDictionary dictionaryWithObjectsAndKeys:@"NO", @"ApplePressAndHoldEnabled", @"NO", @"TransparentTitleBar", @"NO", @"HideDocumentIcon", nil];
+     }
+ }


### PR DESCRIPTION
see issue #281 

This worked for me by installing from my own tap. I'm not an expert on Objective-C, but it should be functionally the same as before, I just edited the patch to place lines in the same context.