### PR TITLE
Fix formula style warnings

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 class EmacsMac < Formula
   desc "YAMAMOTO Mitsuharu's Mac port of GNU Emacs"
   homepage "https://www.gnu.org/software/emacs/"
@@ -8,9 +7,7 @@ class EmacsMac < Formula
 
   head "https://bitbucket.org/mituharu/emacs-mac.git", branch: "work"
 
-  option "with-dbus", "Build with d-bus support"
   option "without-modules", "Build without dynamic modules support"
-  option "with-rsvg", "Build with rsvg support"
   option "with-ctags", "Don't remove the ctags executable that emacs provides"
   option "with-no-title-bars",
          "Build with a patch for no title bars on frames (not recommended to use with --HEAD option)"
@@ -22,31 +19,32 @@ class EmacsMac < Formula
 
   # icons
   ICONS_INFO = {
-    "emacs-big-sur-icon" => "e9ec41167c38842a3f6555d3142909211a2aa7e3ff91621b9a576b3847d3b565",
-    "emacs-icons-project-EmacsIcon1" => "50dbaf2f6d67d7050d63d987fe3743156b44556ab42e6d9eee92248c56011bd0",
-    "emacs-icons-project-EmacsIcon2" => "8d63589b0302a67f13ab94b91683a8ad7c2b9e880eabe008056a246a22592963",
-    "emacs-icons-project-EmacsIcon3" => "80dd2a4776739a081e0a42008e8444c729d41ba876b19fa9d33fde98ee3e0ebf",
-    "emacs-icons-project-EmacsIcon4" => "8ce646ca895abe7f45029f8ff8f5eac7ab76713203e246b70dea1b8a21a6c135",
-    "emacs-icons-project-EmacsIcon5" => "ca415df7ad60b0dc495626b0593d3e975b5f24397ad0f3d802455c3f8a3bd778",
-    "emacs-icons-project-EmacsIcon6" => "12a1999eb006abac11535b7fe4299ebb3c8e468360faf074eb8f0e5dec1ac6b0",
-    "emacs-icons-project-EmacsIcon7" => "f5067132ea12b253fb4a3ea924c75352af28793dcf40b3063bea01af9b2bd78c",
-    "emacs-icons-project-EmacsIcon8" => "d330b15cec1bcdfb8a1e8f8913d8680f5328d59486596fc0a9439b54eba340a0",
-    "emacs-icons-project-EmacsIcon9" => "f58f46e5ef109fff8adb963a97aea4d1b99ca09265597f07ee95bf9d1ed4472e",
-    "emacs-icons-project-emacs-card-blue-deep" => "6bdb17418d2c620cf4132835cfa18dcc459a7df6ce51c922cece3c7782b3b0f9",
+    "emacs-big-sur-icon"                                  => "e9ec41167c38842a3f6555d3142909211a2aa7e3ff91621b9a576b3847d3b565",
+    "emacs-icons-project-EmacsIcon1"                      => "50dbaf2f6d67d7050d63d987fe3743156b44556ab42e6d9eee92248c56011bd0",
+    "emacs-icons-project-EmacsIcon2"                      => "8d63589b0302a67f13ab94b91683a8ad7c2b9e880eabe008056a246a22592963",
+    "emacs-icons-project-EmacsIcon3"                      => "80dd2a4776739a081e0a42008e8444c729d41ba876b19fa9d33fde98ee3e0ebf",
+    "emacs-icons-project-EmacsIcon4"                      => "8ce646ca895abe7f45029f8ff8f5eac7ab76713203e246b70dea1b8a21a6c135",
+    "emacs-icons-project-EmacsIcon5"                      => "ca415df7ad60b0dc495626b0593d3e975b5f24397ad0f3d802455c3f8a3bd778",
+    "emacs-icons-project-EmacsIcon6"                      => "12a1999eb006abac11535b7fe4299ebb3c8e468360faf074eb8f0e5dec1ac6b0",
+    "emacs-icons-project-EmacsIcon7"                      => "f5067132ea12b253fb4a3ea924c75352af28793dcf40b3063bea01af9b2bd78c",
+    "emacs-icons-project-EmacsIcon8"                      => "d330b15cec1bcdfb8a1e8f8913d8680f5328d59486596fc0a9439b54eba340a0",
+    "emacs-icons-project-EmacsIcon9"                      => "f58f46e5ef109fff8adb963a97aea4d1b99ca09265597f07ee95bf9d1ed4472e",
+    "emacs-icons-project-emacs-card-blue-deep"            => "6bdb17418d2c620cf4132835cfa18dcc459a7df6ce51c922cece3c7782b3b0f9",
     "emacs-icons-project-emacs-card-british-racing-green" => "ddf0dff6a958e3b6b74e6371f1a68c2223b21e75200be6b4ac6f0bd94b83e1a5",
-    "emacs-icons-project-emacs-card-carmine" => "4d34f2f1ce397d899c2c302f2ada917badde049c36123579dd6bb99b73ebd7f9",
-    "emacs-icons-project-emacs-card-green" => "f94ade7686418073f04b73937f34a1108786400527ed109af822d61b303048f7",
-    "emacs-sexy-icon" => "7ab72feeeff0084e14bcb75a3e1040bdf738e0044361e7af8a67ebbaa58d852a",
-    "gnu-head-icon" => "b5899aaa3589b54c6f31aa081daf29d303047aa07b5ca1d0fd7f9333a829b6d3",
-    "modern-icon" => "eb819de2380d3e473329a4a5813fa1b4912ec284146c94f28bd24fbb79f8b2c5",
-    "sjrmanning-icon" => "fc267d801432da90de5c0d2254f6de16557193b6c062ccaae30d91b3ada01ab9",
-    "spacemacs-icon" => "b3db8b7cfa4bc5bce24bc4dc1ede3b752c7186c7b54c09994eab5ec4eaa48900",
-    "retro-sink-bw" => "5cd836f86c8f5e1688d6b59bea4b57c8948026a9640257a7d2ec153ea7200571"
+    "emacs-icons-project-emacs-card-carmine"              => "4d34f2f1ce397d899c2c302f2ada917badde049c36123579dd6bb99b73ebd7f9",
+    "emacs-icons-project-emacs-card-green"                => "f94ade7686418073f04b73937f34a1108786400527ed109af822d61b303048f7",
+    "emacs-sexy-icon"                                     => "7ab72feeeff0084e14bcb75a3e1040bdf738e0044361e7af8a67ebbaa58d852a",
+    "gnu-head-icon"                                       => "b5899aaa3589b54c6f31aa081daf29d303047aa07b5ca1d0fd7f9333a829b6d3",
+    "modern-icon"                                         => "eb819de2380d3e473329a4a5813fa1b4912ec284146c94f28bd24fbb79f8b2c5",
+    "sjrmanning-icon"                                     => "fc267d801432da90de5c0d2254f6de16557193b6c062ccaae30d91b3ada01ab9",
+    "spacemacs-icon"                                      => "b3db8b7cfa4bc5bce24bc4dc1ede3b752c7186c7b54c09994eab5ec4eaa48900",
+    "retro-sink-bw"                                       => "5cd836f86c8f5e1688d6b59bea4b57c8948026a9640257a7d2ec153ea7200571",
   }.freeze
   ICONS_INFO.each do |icon, iconsha|
     option "with-#{icon}", "Using Emacs icon: #{icon}"
-    next if build.without? "#{icon}"
-    resource "#{icon}" do
+    next if build.without? icon
+
+    resource icon do
       url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/f27bd8d442fa40d4d96926a6bd94f0889184d966/icons/#{icon}.icns"
       sha256 iconsha
     end
@@ -58,15 +56,15 @@ class EmacsMac < Formula
 
   depends_on "autoconf"
   depends_on "automake"
-  depends_on "d-bus" if build.with? "dbus"
   depends_on "gnutls"
-  depends_on "librsvg" if build.with? "rsvg"
   depends_on "pkg-config"
   depends_on "texinfo"
   depends_on "jansson" => :recommended
   depends_on "libxml2" => :recommended
+  depends_on "dbus" => :optional
   depends_on "glib" => :optional
   depends_on "imagemagick" => :optional
+  depends_on "librsvg" => :optional
 
   if build.with? "no-title-bars"
     # odie "--with-no-title-bars patch not supported on --HEAD" if build.head?
@@ -78,7 +76,7 @@ class EmacsMac < Formula
 
   if build.with? "natural-title-bar"
     patch do
-      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/master/patches/emacs-mac-title-bar-9.0.patch"
+      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/89fc33ae62c82c7ff5894967c1038ef87bb0b418/patches/emacs-mac-title-bar-9.0.patch"
       sha256 "4c719da92bf7744bb7931315ddcca78b190d7513adf49f86e7c2ae93dacfc68b"
     end
   end
@@ -105,7 +103,7 @@ class EmacsMac < Formula
       "--enable-mac-app=#{prefix}",
       "--with-gnutls",
     ]
-    args << "--with-modules" unless build.without? "modules"
+    args << "--with-modules" if build.with? "modules"
     args << "--with-rsvg" if build.with? "rsvg"
     args << "--with-mac-metal" if build.with? "mac-metal"
     args << "--with-native-compilation" if build.with? "native-comp"
@@ -125,7 +123,7 @@ class EmacsMac < Formula
 
     icons_dir = buildpath/"mac/Emacs.app/Contents/Resources"
     ICONS_INFO.each do |icon,|
-      next unless build.with? icon
+      next if build.without? icon
 
       rm "#{icons_dir}/Emacs.icns"
       resource(icon).stage do


### PR DESCRIPTION
This fixes many of the complaints reported by `brew audit --strict --formula Formula/emacs-mac.rb`.

The only functional change is that `--with-rsvg` becomes `--with-librsvg`, but it's now named consistently with the other options, e.g. `--with-libxml2`.

Warnings before:
```
$ brew audit --strict --formula Formula/emacs-mac.rb
emacs-mac:
  * 1: col 1: Unnecessary utf-8 encoding comment.
  * 2: col 1: Add an empty line after magic comments.
  * 25: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 26: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 27: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 28: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 29: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 30: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 31: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 32: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 33: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 34: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 35: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 36: col 119: Line is too long. [128/118]
  * 37: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 38: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 39: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 40: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 41: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 42: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 43: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 44: col 5: Align the keys and values of a hash literal if they span more than one line.
  * 44: col 5: Put a comma after the last item of a multiline hash.
  * 48: col 5: Add empty line after guard clause.
  * 48: col 28: Prefer `to_s` over string interpolation.
  * 49: col 14: Prefer `to_s` over string interpolation.
  * 61: col 25: Use `:optional` or `:recommended` instead of `if build.with? "dbus"`
  * 63: col 27: Use `:optional` or `:recommended` instead of `if build.with? "rsvg"`
  * 81: col 11: GitHub/Gist patches should specify a revision: https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/master/patches/emacs-mac-title-bar-9.0.patch
  * 108: col 37: Use if build.with? "modules" instead of unless build.without? "modules"
  * 128: col 19: Use if build.without? icon instead of unless build.with? icon
  * Emacs Lisp files were linked directly to "/usr/local/share/emacs/site-lisp".
    This may cause conflicts with other packages.
    They should instead be installed into:
      /usr/local/opt/emacs-mac/share/emacs/site-lisp/emacs-mac
    The offending files are:
      /usr/local/opt/emacs-mac/share/emacs/site-lisp/subdirs.el
  * Files were found with references to the Homebrew shims directory.
    The offending files are:
      libexec/emacs/28.1/x86_64-apple-darwin21.4.0/emacs.pdmp
      Emacs.app/Contents/MacOS/Emacs.pdmp
Error: 33 problems in 1 formula detected
```

and after:
```
$ brew audit --strict --formula Formula/emacs-mac.rb
emacs-mac:
  * 22: col 119: Line is too long. [128/118]
  * 23: col 119: Line is too long. [128/118]
  * 24: col 119: Line is too long. [128/118]
  * 25: col 119: Line is too long. [128/118]
  * 26: col 119: Line is too long. [128/118]
  * 27: col 119: Line is too long. [128/118]
  * 28: col 119: Line is too long. [128/118]
  * 29: col 119: Line is too long. [128/118]
  * 30: col 119: Line is too long. [128/118]
  * 31: col 119: Line is too long. [128/118]
  * 32: col 119: Line is too long. [128/118]
  * 33: col 119: Line is too long. [128/118]
  * 34: col 119: Line is too long. [128/118]
  * 35: col 119: Line is too long. [128/118]
  * 36: col 119: Line is too long. [128/118]
  * 37: col 119: Line is too long. [128/118]
  * 38: col 119: Line is too long. [128/118]
  * 39: col 119: Line is too long. [128/118]
  * 40: col 119: Line is too long. [128/118]
  * 41: col 119: Line is too long. [128/118]
  * Emacs Lisp files were linked directly to "/usr/local/share/emacs/site-lisp".
    This may cause conflicts with other packages.
    They should instead be installed into:
      /usr/local/opt/emacs-mac/share/emacs/site-lisp/emacs-mac
    The offending files are:
      /usr/local/opt/emacs-mac/share/emacs/site-lisp/subdirs.el
  * Files were found with references to the Homebrew shims directory.
    The offending files are:
      libexec/emacs/28.1/x86_64-apple-darwin21.4.0/emacs.pdmp
      Emacs.app/Contents/MacOS/Emacs.pdmp
Error: 22 problems in 1 formula detected
```