### PR TITLE
Put info and man files in the right place for brew

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -99,7 +99,8 @@ class EmacsMac < Formula
   def install
     args = [
       "--enable-locallisppath=#{HOMEBREW_PREFIX}/share/emacs/site-lisp",
-      "--infodir=#{info}/emacs",
+      "--infodir=#{info}",
+      "--mandir=#{man}",
       "--prefix=#{prefix}",
       "--with-mac",
       "--enable-mac-app=#{prefix}",


### PR DESCRIPTION
This addresses most of #242 and handles an unfiled issue about man pages installed by emacs similarly failing to show up.

The remaining issue is that homebrew doesn't run `install-info`, ever.  I'm trying to get a clean `brew doctor` output so I can report that problem to them.

In the meantime I have this `brew-info-update` script that I run:

```sh
#!/usr/bin/env sh
cd "$HOMEBREW_PREFIX/share/info"
mv dir dir.orig
for file in *; do install-info --calign=36 --align=36 $file dir; done
```