### PR TITLE
Put `man` files in the right place for the cask

### DIFF
--- a/Casks/emacs-mac.rb
+++ b/Casks/emacs-mac.rb
@@ -37,6 +37,10 @@ cask 'emacs-mac' do
   binary "#{appdir}/Emacs.app/Contents/MacOS/bin/etags"
   binary "#{appdir}/Emacs.app/Contents/Resources/include/emacs-module.h", target: "#{HOMEBREW_PREFIX}/include/emacs-module.h"
   binary "#{appdir}/Emacs.app/Contents/Resources/site-lisp/subdirs.el", target: "#{HOMEBREW_PREFIX}/share/emacs/site-lisp/subdirs.el"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/ebrowse.1.gz"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacs.1.gz"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/emacsclient.1.gz"
+  manpage "#{appdir}/Emacs.app/Contents/Resources/man/man1/etags.1.gz"
 
   zap trash: [
                '~/Library/Caches/org.gnu.Emacs',


### PR DESCRIPTION
This complements #316 for the cask code. It also aligns with `emacs.rb` in the `homebrew-cask` repo. However, it does not deal with the `info` files since those would require external program `install-info` to work properly.