### PR TITLE
Use different multi-tty patch for emacs-mac-28.3-rc1

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -91,9 +91,17 @@ class EmacsMac < Formula
   # patch for multi-tty support, see the following links for details
   # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
   # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
-  patch do
-    url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/667f0efc08506facfc6963ac1fd1d5b9b777e094/patches/multi-tty-27.diff"
-    sha256 "5a13e83e79ce9c4a970ff0273e9a3a07403cc07f7333a0022b91c191200155a1"
+  # starting with emacs-mac-28.3-rc1 (changes introduced in commit 45c40d3ec0) there needs to be a different patch applied
+  if build.head?
+    patch do
+      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/540c5b87c8160c68725029cbc4d9d60d332d6100/patches/emacs-mac-28.3-rc-1-multi-tty-27.diff"
+      sha256 "b0e26dd07d089786a59faebe138820f01ff0365fb9c9597b47c7b07c451fea56"
+    end
+  else
+    patch do
+      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/667f0efc08506facfc6963ac1fd1d5b9b777e094/patches/multi-tty-27.diff"
+      sha256 "5a13e83e79ce9c4a970ff0273e9a3a07403cc07f7333a0022b91c191200155a1"
+    end
   end
 
   def install

--- a/patches/emacs-mac-28.3-rc-1-multi-tty-27.diff
+++ b/patches/emacs-mac-28.3-rc-1-multi-tty-27.diff
@@ -1,0 +1,58 @@
+diff --git a/lisp/server.el b/lisp/server.el
+index 3429e4362a..8b93a4a272 100644
+--- a/lisp/server.el
++++ b/lisp/server.el
+@@ -1217,10 +1217,9 @@ The following commands are accepted by the client:
+                  ;; choice there.)  In daemon mode on Windows, we can't
+                  ;; make tty frames, so force the frame type to GUI
+                  ;; there too.
+-                 (when (or (and (eq system-type 'windows-nt)
+-                                (or (daemonp)
+-                                    (eq window-system 'w32)))
+-                           (eq window-system 'mac))
++                 (when (and (eq system-type 'windows-nt)
++                            (or (daemonp)
++                                (eq window-system 'w32)))
+                    (push "-window-system" args-left)))
+ 
+                 ;; -position +LINE[:COLUMN]:  Set point to the given
+diff --git a/src/frame.c b/src/frame.c
+index 3782857826..3a1fd3ef82 100644
+--- a/src/frame.c
++++ b/src/frame.c
+@@ -1343,12 +1343,8 @@ affects all frames on the same terminal device.  */)
+     emacs_abort ();
+ #else /* not MSDOS */
+ 
+-#if defined WINDOWSNT || defined HAVE_MACGUI /* This should work now! */
+-  if (sf->output_method != output_termcap
+-#ifdef HAVE_MACGUI
+-      && sf->output_method != output_initial
+-#endif
+-      )
++#ifdef WINDOWSNT /* This should work now! */
++  if (sf->output_method != output_termcap)
+     error ("Not using an ASCII terminal now; cannot make a new ASCII frame");
+ #endif
+ #endif /* not MSDOS */
+diff --git a/src/macterm.c b/src/macterm.c
+index c25236b9ac..77a9515cff 100644
+--- a/src/macterm.c
++++ b/src/macterm.c
+@@ -2939,6 +2939,7 @@ mac_mouse_position (struct frame **fp, int insist, Lisp_Object *bar_window,
+ {
+   struct frame *f1;
+   struct mac_display_info *dpyinfo = FRAME_DISPLAY_INFO (*fp);
++  struct frame *sf = SELECTED_FRAME ();
+ 
+   block_input ();
+ 
+@@ -2971,7 +2972,7 @@ mac_mouse_position (struct frame **fp, int insist, Lisp_Object *bar_window,
+ 	f1 = XFRAME (mac_event_frame ());
+     }
+ 
+-  if (f1)
++  if (f1 && sf->output_method != output_termcap)
+     {
+       /* Ok, we found a frame.  Store all the values.
+ 	 last_mouse_glyph is a rectangle used to reduce the generation


### PR DESCRIPTION
Starting with emacs-mac-28.3-rc1 (changes introduced in commit [45c40d3ec0](https://bitbucket.org/mituharu/emacs-mac/commits/45c40d3ec040adcbec13f96881ae7de6b776182a)) there needs to be a different patch applied. I decided to go with `head` build to select this one, as currently there is no version available.

Note: this PR consists of two commits. If you decide to accept it, please do not squash (which seems to be a new trend). I explicitly added patch in a separate commit such that there exist a fully qualified URL to fetch the patch from.