### PR TITLE
Use stable and head blocks for multi-tty patch

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -1,11 +1,30 @@
 class EmacsMac < Formula
   desc "YAMAMOTO Mitsuharu's Mac port of GNU Emacs"
   homepage "https://www.gnu.org/software/emacs/"
-  url "https://bitbucket.org/mituharu/emacs-mac/get/emacs-28.2-mac-9.1.tar.gz"
-  version "emacs-28.2-mac-9.1"
-  sha256 "9287262473589c1edfe42e92b183a8ddf1682c995e81763adfdf95160874843e"
+  stable do
+    url "https://bitbucket.org/mituharu/emacs-mac/get/emacs-28.2-mac-9.1.tar.gz"
+    version "emacs-28.2-mac-9.1"
+    sha256 "9287262473589c1edfe42e92b183a8ddf1682c995e81763adfdf95160874843e"
+    patch do
+      # patch for multi-tty support, see the following links for details
+      # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
+      # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
+      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/667f0efc08506facfc6963ac1fd1d5b9b777e094/patches/multi-tty-27.diff"
+      sha256 "5a13e83e79ce9c4a970ff0273e9a3a07403cc07f7333a0022b91c191200155a1"
+    end
+  end
 
-  head "https://bitbucket.org/mituharu/emacs-mac.git", branch: "work"
+  head do
+    url "https://bitbucket.org/mituharu/emacs-mac.git", branch: "work"
+    # patch for multi-tty support, see the following links for details
+    # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
+    # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
+    # starting with emacs-mac-28.3-rc1 (changes introduced in commit 45c40d3ec0) there needs to be a different patch applied
+    patch do
+      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/540c5b87c8160c68725029cbc4d9d60d332d6100/patches/emacs-mac-28.3-rc-1-multi-tty-27.diff"
+      sha256 "b0e26dd07d089786a59faebe138820f01ff0365fb9c9597b47c7b07c451fea56"
+    end
+  end
 
   option "without-modules", "Build without dynamic modules support"
   option "with-ctags", "Don't remove the ctags executable that emacs provides"
@@ -86,22 +105,6 @@ class EmacsMac < Formula
   if (build.with? "native-comp") || (build.with? "native-compilation")
     depends_on "libgccjit" => :recommended
     depends_on "gcc" => :build
-  end
-
-  # patch for multi-tty support, see the following links for details
-  # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
-  # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
-  # starting with emacs-mac-28.3-rc1 (changes introduced in commit 45c40d3ec0) there needs to be a different patch applied
-  if build.head?
-    patch do
-      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/540c5b87c8160c68725029cbc4d9d60d332d6100/patches/emacs-mac-28.3-rc-1-multi-tty-27.diff"
-      sha256 "b0e26dd07d089786a59faebe138820f01ff0365fb9c9597b47c7b07c451fea56"
-    end
-  else
-    patch do
-      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/667f0efc08506facfc6963ac1fd1d5b9b777e094/patches/multi-tty-27.diff"
-      sha256 "5a13e83e79ce9c4a970ff0273e9a3a07403cc07f7333a0022b91c191200155a1"
-    end
   end
 
   def install


### PR DESCRIPTION
The change introduced in #321 incorrectly uses `build.head?` outside of `install`. This one utilises `head` and `stable` blocks to correctly pick patches depending on version.

This time I tested it and it successfully build `--HEAD` flag as well as without it, i.e.,

```
brew install emacs-mac --HEAD --with-librsvg --with-natural-title-bar --with-mac-metal --with-native-comp --with-xwidgets
Warning: Treating emacs-mac as a formula. For the cask, use railwaycat/emacsmacport/emacs-mac
[...]
Warning: Treating emacs-mac as a formula. For the cask, use railwaycat/emacsmacport/emacs-mac
==> Fetching railwaycat/emacsmacport/emacs-mac
==> Downloading https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/540c5b87c8160c68725029cbc4d9d60d332d6100/patches/emacs-mac-28.3-rc-1-multi-tty-27.diff
######################################################################## 100.0%
==> Downloading https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/89fc33ae62c82c7ff5894967c1038ef87bb0b418/patches/emacs-mac-title-bar-9.0.patch
Already downloaded: /Users/pkryger/Library/Caches/Homebrew/downloads/573b7691e5aaf401ce257319af89ab6326c4d3b1a79f30c2d4acd2d7b137f0db--emacs-mac-title-bar-9.0.patch
==> Cloning https://bitbucket.org/mituharu/emacs-mac.git
Updating /Users/pkryger/Library/Caches/Homebrew/emacs-mac--git
From https://bitbucket.org/mituharu/emacs-mac
   42fd87989f..bb741d4839  work       -> origin/work
==> Checking out branch work
Already on 'work'
Your branch is behind 'origin/work' by 1 commit, and can be fast-forwarded.
  (use "git pull" to update your local branch)
HEAD is now at bb741d4839 explicitly declare void arg
==> Installing emacs-mac from railwaycat/emacsmacport
==> Patching
==> Applying emacs-mac-28.3-rc-1-multi-tty-27.diff
patching file lisp/server.el
patching file src/frame.c
patching file src/macterm.c
==> Applying emacs-mac-title-bar-9.0.patch
patching file src/macappkit.m
Hunk #2 succeeded at 2511 (offset 4 lines).
Hunk #3 succeeded at 6384 (offset 50 lines).
==> ./autogen.sh
==> ./configure --enable-locallisppath=/opt/homebrew/share/emacs/site-lisp --infodir=/opt/homebrew/Cellar/emacs-mac/HEAD-bb741d4/share/info --mandir=/opt/homebrew/Cellar/emacs-mac/HEAD-bb741d4/share/man --prefix=/opt/homebrew/Cellar/emacs-mac/HEAD-bb741d4 --with-mac --enable-mac-app=/opt/homebrew/Cellar/emacs-mac/HEA
==> make
==> make install
[...]
```

``` text
brew install emacs-mac --with-natural-title-bar --with-native-compilation --with-xwidgets --with-librsvg
[...]
Warning: Treating emacs-mac as a formula. For the cask, use railwaycat/emacsmacport/emacs-mac
==> Fetching railwaycat/emacsmacport/emacs-mac
==> Downloading https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/667f0efc08506facfc6963ac1fd1d5b9b777e094/patches/multi-tty-27.diff
Already downloaded: /Users/pkryger/Library/Caches/Homebrew/downloads/8a6c12e323fded340e400b297b7cf56254dc256768d95a99b74d9d2b0cb3806a--multi-tty-27.diff
==> Downloading https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/89fc33ae62c82c7ff5894967c1038ef87bb0b418/patches/emacs-mac-title-bar-9.0.patch
Already downloaded: /Users/pkryger/Library/Caches/Homebrew/downloads/573b7691e5aaf401ce257319af89ab6326c4d3b1a79f30c2d4acd2d7b137f0db--emacs-mac-title-bar-9.0.patch
==> Downloading https://bitbucket.org/mituharu/emacs-mac/get/emacs-28.2-mac-9.1.tar.gz
######################################################################## 100.0%
==> Installing emacs-mac from railwaycat/emacsmacport
==> Patching
==> Applying multi-tty-27.diff
patching file 'lisp/server.el'
patching file 'src/frame.c'
patching file 'src/macterm.c'
==> Applying emacs-mac-title-bar-9.0.patch
patching file 'src/macappkit.m'
==> ./autogen.sh
==> ./configure --enable-locallisppath=/opt/homebrew/share/emacs/site-lisp --infodir=/opt/homebrew/Cellar/emacs-mac/emacs-28.2-mac-9.1/share/info --mandir=/opt/homebrew/Cellar/emacs-
==> make
==> make install
```

fixes #322
fixes #321