### PR TITLE
Remove appcast

### DIFF
--- a/Casks/emacs-mac.rb
+++ b/Casks/emacs-mac.rb
@@ -20,7 +20,6 @@ cask 'emacs-mac' do
     url 'https://github.com/railwaycat/homebrew-emacsmacport/releases/download/emacs-28.2-mac-9.1/emacs-28.2-mac-9.1-arm64-12.5.1.zip'
   end
 
-  appcast 'https://github.com/railwaycat/homebrew-emacsmacport/releases.atom'
   name 'Emacs-mac'
   homepage 'https://bitbucket.org/mituharu/emacs-mac.git'
   desc "YAMAMOTO Mitsuharu's Mac port of GNU Emacs"


### PR DESCRIPTION
The `appcast` stanza has been deprecated in a recent version of Homebrew. This causes a warning to be printed for every Homebrew command:
```
Warning: Calling the `appcast` stanza is deprecated! Use the `livecheck` stanza instead.
Please report this issue to the railwaycat/emacsmacport tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/railwaycat/homebrew-emacsmacport/Casks/emacs-mac.rb:23
```

However, I don't think there is any point in having `appcast` or `livecheck` for this cask since it's a custom tap where the cask definition and release are published together.