### PR TITLE
Replace `appcast` with a `livecheck` stanza

### DIFF
--- a/Casks/emacs-mac.rb
+++ b/Casks/emacs-mac.rb
@@ -20,7 +20,10 @@ cask 'emacs-mac' do
     url 'https://github.com/railwaycat/homebrew-emacsmacport/releases/download/emacs-28.2-mac-9.1/emacs-28.2-mac-9.1-arm64-12.5.1.zip'
   end
 
-  appcast 'https://github.com/railwaycat/homebrew-emacsmacport/releases.atom'
+  livecheck do
+    url 'https://github.com/railwaycat/homebrew-emacsmacport/releases.atom'
+  end
+
   name 'Emacs-mac'
   homepage 'https://bitbucket.org/mituharu/emacs-mac.git'
   desc "YAMAMOTO Mitsuharu's Mac port of GNU Emacs"


### PR DESCRIPTION
The formula in its current form triggers the following Homebrew response:
```
Warning: Calling the `appcast` stanza is deprecated! Use the `livecheck` stanza instead.
```
This patch follows those instructions, using the same URL but placing it inside of a `livecheck` block, quieting the warning message.