### PR TITLE
Add tree-sitter support for emacs-29

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -16,6 +16,7 @@ class EmacsMac < Formula
 
   head do
     url "https://bitbucket.org/mituharu/emacs-mac.git", branch: "work"
+    depends_on "tree-sitter"
     patch do
       # patch for multi-tty support, see the following links for details
       # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff


### PR DESCRIPTION
When emacs-mac is installed with the "--HEAD" option, it will build with the latest "work" branch containing Emacs 29.1. However, the configure program can not find the brew installed tree-sitter. This will result in a build lacking the tree-sitter support. I have explained it [here](https://github.com/railwaycat/homebrew-emacsmacport/issues/346#issuecomment-1664904733). This pull request addresses this issue.

Thanks.