### PR TITLE
Ensure info files are installed

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -170,6 +170,10 @@ class EmacsMac < Formula
     if (build.with? "native-comp") || (build.with? "native-compilation")
       ln_sf "#{Dir[opt_prefix/"lib/emacs/*"].first}/native-lisp", "#{opt_prefix}/Emacs.app/Contents/native-lisp"
     end
+    (info/"dir").delete if (info/"dir").exist?
+    info.glob("*.info{,.gz}") do |f|
+      quiet_system Formula["texinfo"].bin/"install-info", "--quiet", "--info-dir=#{info}", f
+    end
   end
 
   def caveats


### PR DESCRIPTION
This is a follow up to #316, basically implementing workaround proposed by @dabrahams.

What I saw was the following in `04.make` Homebrew log:

```
thisdir=`pwd -P`; \
exp_infodir=`cd "/opt/homebrew/Cellar/emacs-mac/HEAD-719b04b/share/info" && pwd -P`; \
if [ "`cd ./info && pwd -P`" = "$exp_infodir" ]; then \
  true; \
else \
   [ -f "/opt/homebrew/Cellar/emacs-mac/HEAD-719b04b/share/info/dir" ] || \
      [ ! -f ./info/dir ] || \
      /usr/bin/install -c -m 644 ./info/dir "/opt/homebrew/Cellar/emacs-mac/HEAD-719b04b/share/info/dir"; \
   info_misc=`MAKEFLAGS= /Library/Developer/CommandLineTools/usr/bin/make --no-print-directory -s -C doc/misc echo-info`; \
   cd ./info ; \
   for elt in emacs.info eintr.info elisp.info ${info_misc}; do \
      for f in `ls $elt $elt-[1-9] $elt-[1-9][0-9] 2>/dev/null`; do \
       (cd "${thisdir}"; \
        /usr/bin/install -c -m 644 ./info/$f "/opt/homebrew/Cellar/emacs-mac/HEAD-719b04b/share/info/$f"); \
        [ -n "/usr/bin/gzip" ] || continue ; \
        rm -f "/opt/homebrew/Cellar/emacs-mac/HEAD-719b04b/share/info/$f.gz"; \
        /usr/bin/gzip -9n "/opt/homebrew/Cellar/emacs-mac/HEAD-719b04b/share/info/$f"; \
      done; \
     (cd "${thisdir}"; \
      /opt/homebrew/opt/texinfo/bin/install-info --info-dir="/opt/homebrew/Cellar/emacs-mac/HEAD-719b04b/share/info" "/opt/homebrew/Cellar/emacs-mac/HEAD-719b04b/share/info/$elt"); \
   done; \
fi
```

My guess is that `elt` was latching to a `.info` file, however the file has been compressed and is now a `.info.gz` file, however, I don't have a spare resources now to debug it further