### PR TITLE
Add friendly install command example

### DIFF
--- a/docs/emacs-start-helpers.md
+++ b/docs/emacs-start-helpers.md
@@ -44,6 +44,9 @@ Cons: Need to repeat the install step for every upgrade and build option change.
 
 #### Installation
 Copy the `Emacs.app` from `$(brew --prefix)/opt/emacs-mac/` to `/Applications` manually or by a shell script.
+```bash
+cp -a $(brew --prefix)/opt/emacs-mac/Emacs.app /Applications
+```
 
 ### Helper 2
 Create a simple app bundle that opens `Emacs.app` under Homebrew directory.


### PR DESCRIPTION
I accidentally copied directory `emacs-mac` to Applications, not Emacs.app, so adding actual copy command example is helpful for someone like me.