### PR TITLE
Update formula to use multi-tty patch for emacs-29.2-rc-1

### DIFF
--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -74,12 +74,22 @@ class EmacsMac < Formula
   depends_on "imagemagick" => :optional
   depends_on "librsvg" => :optional
 
-  patch do
-    # patch for multi-tty support, see the following links for details
-    # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
-    # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
-    url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/8b06f75ea28a68f9a490d9001ce33fd1b0d426aa/patches/emacs-mac-29-multi-tty.diff"
-    sha256 "4412ce35689e3caf8e8b1d751bf3641b473cd3aef11889d3ecd682474bf204b0"
+  if build.head?
+    patch do
+      # patch for multi-tty support, see the following links for details
+      # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
+      # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
+      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/4ff55f8bfc70078c168749a399c87e2d26ee591b/patches/emacs-mac-29.2-rc-1-multi-tty.diff"
+      sha256 "4ede698c8f8f5509e3abf4e6a9c73e1dc3909b0f52f52ad4c33068bfaed3d1e4"
+    end
+  else
+    patch do
+      # patch for multi-tty support, see the following links for details
+      # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
+      # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
+      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/8b06f75ea28a68f9a490d9001ce33fd1b0d426aa/patches/emacs-mac-29-multi-tty.diff"
+      sha256 "4412ce35689e3caf8e8b1d751bf3641b473cd3aef11889d3ecd682474bf204b0"
+    end
   end
 
   if build.with? "no-title-bars"

--- a/Formula/emacs-mac.rb
+++ b/Formula/emacs-mac.rb
@@ -5,10 +5,24 @@ class EmacsMac < Formula
     url "https://bitbucket.org/mituharu/emacs-mac/get/65c6c96f27afa446df6f9d8eff63f9cc012cc738.tar.gz"
     version "emacs-29.1-mac-10.0"
     sha256 "54d7ba79157c8cb7c3e20be5ce0fbcddd3d5bd0b339b11bc628d7c67a4765b9b"
+    patch do
+      # patch for multi-tty support, see the following links for details
+      # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
+      # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
+      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/8b06f75ea28a68f9a490d9001ce33fd1b0d426aa/patches/emacs-mac-29-multi-tty.diff"
+      sha256 "4412ce35689e3caf8e8b1d751bf3641b473cd3aef11889d3ecd682474bf204b0"
+    end
   end
 
   head do
     url "https://bitbucket.org/mituharu/emacs-mac.git", branch: "work"
+    patch do
+      # patch for multi-tty support, see the following links for details
+      # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
+      # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
+      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/4ff55f8bfc70078c168749a399c87e2d26ee591b/patches/emacs-mac-29.2-rc-1-multi-tty.diff"
+      sha256 "4ede698c8f8f5509e3abf4e6a9c73e1dc3909b0f52f52ad4c33068bfaed3d1e4"
+    end
   end
 
   option "without-modules", "Build without dynamic modules support"
@@ -73,24 +87,6 @@ class EmacsMac < Formula
   depends_on "glib" => :optional
   depends_on "imagemagick" => :optional
   depends_on "librsvg" => :optional
-
-  if build.head?
-    patch do
-      # patch for multi-tty support, see the following links for details
-      # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
-      # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
-      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/4ff55f8bfc70078c168749a399c87e2d26ee591b/patches/emacs-mac-29.2-rc-1-multi-tty.diff"
-      sha256 "4ede698c8f8f5509e3abf4e6a9c73e1dc3909b0f52f52ad4c33068bfaed3d1e4"
-    end
-  else
-    patch do
-      # patch for multi-tty support, see the following links for details
-      # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
-      # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
-      url "https://raw.githubusercontent.com/railwaycat/homebrew-emacsmacport/8b06f75ea28a68f9a490d9001ce33fd1b0d426aa/patches/emacs-mac-29-multi-tty.diff"
-      sha256 "4412ce35689e3caf8e8b1d751bf3641b473cd3aef11889d3ecd682474bf204b0"
-    end
-  end
 
   if build.with? "no-title-bars"
     # odie "--with-no-title-bars patch not supported on --HEAD" if build.head?

--- a/build-scripts/fetch-emacs-mac-port.sh
+++ b/build-scripts/fetch-emacs-mac-port.sh
@@ -6,9 +6,11 @@ MACPORT_VAR="$1"
 COMMIT_HASH="$2"
 OUTPUT_DIR="$3"
 
+MULTI_TTY_PATCH=emacs-mac-29-multi-tty.diff
 echo "fetch tarball"
 if [ "$1" = "head" ]; then
   git clone --depth=1 --branch=work https://bitbucket.org/mituharu/emacs-mac.git "$OUTPUT_DIR"
+  MULTI_TTY_PATCH=emacs-mac-29.2-rc-1-multi-tty.diff
 else
   curl -L "https://bitbucket.org/mituharu/emacs-mac/get/$COMMIT_HASH.tar.gz" -o "emacs-$MACPORT_VAR.tar.gz"
   mkdir "$OUTPUT_DIR"
@@ -19,7 +21,7 @@ echo "apply patch: --with-natural-title-bar"
 patch -d "$OUTPUT_DIR" -p1 < ../patches/emacs-mac-title-bar-9.1.patch
 
 echo "apply patch: multi-tty-27"
-patch -d "$OUTPUT_DIR" -p1 < ../patches/emacs-mac-29-multi-tty.diff
+patch -d "$OUTPUT_DIR" -p1 < ../patches/${MULTI_TTY_PATCH}
 
 echo "apply patch: bundle structure signature hack"
 # this is a hack to let pdump be installed under Contents/MacOS and libexec

--- a/patches/emacs-mac-29.2-rc-1-multi-tty.diff
+++ b/patches/emacs-mac-29.2-rc-1-multi-tty.diff
@@ -1,0 +1,52 @@
+diff --git a/lisp/server.el b/lisp/server.el
+index fcc45be7e7..9770bf327c 100644
+--- a/lisp/server.el
++++ b/lisp/server.el
+@@ -1268,7 +1268,6 @@ The following commands are accepted by the client:
+                  (when (or (and (eq system-type 'windows-nt)
+                                 (or (daemonp)
+                                     (eq window-system 'w32)))
+-                           (eq window-system 'mac)
+                            ;; Client runs on Windows, but the server
+                            ;; runs on a Posix host.
+                            (equal tty-name "CONOUT$"))
+diff --git a/src/frame.c b/src/frame.c
+index 17c72b4799..42b78b5c2c 100644
+--- a/src/frame.c
++++ b/src/frame.c
+@@ -1351,12 +1351,8 @@ affects all frames on the same terminal device.  */)
+     emacs_abort ();
+ #else /* not MSDOS */
+ 
+-#if defined WINDOWSNT || defined HAVE_MACGUI /* This should work now! */
+-  if (sf->output_method != output_termcap
+-#ifdef HAVE_MACGUI
+-      && sf->output_method != output_initial
+-#endif
+-      )
++#ifdef WINDOWSNT /* This should work now! */
++  if (sf->output_method != output_termcap)
+     error ("Not using an ASCII terminal now; cannot make a new ASCII frame");
+ #endif
+ #endif /* not MSDOS */
+diff --git a/src/macterm.c b/src/macterm.c
+index 936a57d2ff..3c89a472d0 100644
+--- a/src/macterm.c
++++ b/src/macterm.c
+@@ -2979,6 +2979,7 @@ mac_mouse_position (struct frame **fp, int insist, Lisp_Object *bar_window,
+ {
+   struct frame *f1;
+   struct mac_display_info *dpyinfo = FRAME_DISPLAY_INFO (*fp);
++  struct frame *sf = SELECTED_FRAME ();
+   bool return_no_frame_flag = false;
+ 
+   block_input ();
+@@ -3018,7 +3019,7 @@ mac_mouse_position (struct frame **fp, int insist, Lisp_Object *bar_window,
+ 	f1 = XFRAME (mac_event_frame ());
+     }
+ 
+-  if (f1)
++  if (f1 && sf->output_method != output_termcap)
+     {
+       /* Ok, we found a frame.  Store all the values.
+ 	 last_mouse_glyph is a rectangle used to reduce the generation


### PR DESCRIPTION
This updates the `multi-tty-patch` for emacs-29.2-rc-1 as changes in upstream since [this commit](https://bitbucket.org/mituharu/emacs-mac/commits/2e2dbe157f7ed18f84a5fd0f2e5b979d3d4235f0). This is similar to work in #321, that is it should allow to install with `--HEAD` while maintaining compatibility with latest tag.

Also this applies same simple heuristics to select patch in `fetch-emacs-mac-port.sh`. However, I'm not fully aware how the script is intended to be used, so it may be not enough.