### PR TITLE
Fix quote issue for helper 2 installation

### DIFF
--- a/docs/emacs-start-helpers.md
+++ b/docs/emacs-start-helpers.md
@@ -57,7 +57,7 @@ Cons: Hard to be pinned on Dock.
 #### Installation
 Run the command below to create a starter app bundle. Rename it if possible and place it under `/Applications` or other preferred places.
 ```
-osacompile -o Emacs.app -e "tell application \"Finder\" to open POSIX file \"$(brew --prefix)/opt/emacs-mac/Emacs.app\""
+osacompile -o Emacs.app -e 'tell application "Finder" to open POSIX file "'"$(brew --prefix)"'/opt/emacs-mac/Emacs.app"'
 ```
 
 ### Helper 3


### PR DESCRIPTION
current use of nested quotes could not be properly executed in command line. Use nested single quote and double quotes to properly