### PR TITLE
fix: Use prefix path when creating symlink in post_install

### DIFF
--- a/Formula/emacs-mac@29.rb
+++ b/Formula/emacs-mac@29.rb
@@ -170,7 +170,7 @@ class EmacsMacAT29 < Formula
 
   def post_install
     if (build.with? "native-comp") || (build.with? "native-compilation")
-      ln_sf "#{Dir[opt_prefix/"lib/emacs/*"].first}/native-lisp", "#{opt_prefix}/Emacs.app/Contents/native-lisp"
+      ln_sf "#{Dir[prefix/"lib/emacs/*"].first}/native-lisp", "#{prefix}/Emacs.app/Contents/native-lisp"
     end
     (info/"dir").delete if (info/"dir").exist?
     info.glob("*.info{,.gz}") do |f|


### PR DESCRIPTION
This fixes installation with `--skip-link`. When no links are created the `opt_prefix` is not created, thus the symlink creation fails.  This also allows to run `brew postinstall emacs-mac` when it has been installed with `--skip-link`.