### PR TITLE
updated Formula/emacs-mac@29.rb to replace ts_language_version with ts_language_api_version.

### DIFF
--- a/Formula/emacs-mac@29.rb
+++ b/Formula/emacs-mac@29.rb
@@ -137,6 +137,9 @@ class EmacsMacAT29 < Formula
       end
     end
 
+    # cf. https://mirror.slackware.jp/slackware/slackware64-current/extra/source/emacs-regular-build/emacs.SlackBuild.with-native-compilation
+    system "sed -i '' -e 's/ts_language_version/ts_language_abi_version/g' src/treesit.c"
+
     system "./autogen.sh"
     system "./configure", *args
     system "make"


### PR DESCRIPTION
The Homebrew formula now uses tree-sitter v0.62.x, which replaces `ts_language_version` with `ts_language_abi_version`. This patch applies this change.