### PR TITLE
Update multi TTY patch for Emacs 31

### DIFF
--- a/Formula/emacs-mac@31exp.rb
+++ b/Formula/emacs-mac@31exp.rb
@@ -1,5 +1,5 @@
-require_relative "../Library/UrlResolver.rb"
-require_relative "../Library/Icons.rb"
+require_relative "../Library/UrlResolver"
+require_relative "../Library/Icons"
 
 class EmacsMacAT31exp < Formula
   desc "YAMAMOTO Mitsuharu's Mac port of GNU Emacs (GNU master experimental)"
@@ -9,43 +9,19 @@ class EmacsMacAT31exp < Formula
 
   # This formula only supports HEAD builds tracking GNU Emacs master
   # Install with: brew install --HEAD emacs-mac@31exp
-  head "https://github.com/jdtsmith/emacs-mac.git", branch: "emacs-mac-gnu_master_exp"
-
   license "GPL-3.0-or-later"
-
-  patch do
-    # patch for multi-tty support, see the following links for details
-    # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
-    # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
-    url (@@urlResolver.patch_url "emacs-mac-29.2-rc-1-multi-tty"), using: CopyDownloadStrategy
-    sha256 "4ede698c8f8f5509e3abf4e6a9c73e1dc3909b0f52f52ad4c33068bfaed3d1e4"
-  end
-
-  patch do
-    url (@@urlResolver.patch_url "prefer-typo-ascender-descender-linegap"), using: CopyDownloadStrategy
-    sha256 "318395d3869d3479da4593360bcb11a5df08b494b995287074d0d744ec562c17"
-  end
+  head "https://github.com/jdtsmith/emacs-mac.git", branch: "emacs-mac-gnu_master_exp"
 
   option "without-modules", "Build without dynamic modules support"
   option "with-no-title-bars", "Build with a patch for no title bars on frames"
   option "with-starter", "Build with a starter script to start emacs GUI from CLI"
   option "with-mac-metal", "use Metal framework in application-side double buffering (experimental)"
-  option "with-native-comp", \
+  option "with-native-comp",
          "Build with native compilation (same as \"--with-native-compilation\", for compatibility only)"
+
   option "with-native-compilation", "Build with native compilation"
   option "with-xwidgets", "Build with xwidgets"
   option "with-unlimited-select", "Builds with unlimited select, which increases emacs's open file limit to 10000"
-
-  # icons
-  ICONS_INFO.each do |icon, iconsha|
-    option "with-#{icon}", "Using Emacs icon: #{icon}"
-    next if build.without? icon
-
-    resource icon do
-      url (@@urlResolver.icon_url icon), using: CopyDownloadStrategy
-      sha256 iconsha
-    end
-  end
 
   deprecated_option "icon-official" => "with-official-icon"
   deprecated_option "icon-modern" => "with-modern-icon"
@@ -62,6 +38,30 @@ class EmacsMacAT31exp < Formula
   depends_on "glib" => :optional
   depends_on "imagemagick" => :optional
   depends_on "librsvg" => :optional
+
+  patch do
+    # patch for multi-tty support, see the following links for details
+    # https://bitbucket.org/mituharu/emacs-mac/pull-requests/2/add-multi-tty-support-to-be-on-par-with/diff
+    # https://ylluminarious.github.io/2019/05/23/how-to-fix-the-emacs-mac-port-for-multi-tty-access/
+    url (@@urlResolver.patch_url "emacs-mac-31-multi-tty"), using: CopyDownloadStrategy
+    sha256 "d8f984ec2f9e7f94821155e729472031dd89f07612fffa23bc8cfde0b1bf9ad6"
+  end
+
+  patch do
+    url (@@urlResolver.patch_url "prefer-typo-ascender-descender-linegap"), using: CopyDownloadStrategy
+    sha256 "318395d3869d3479da4593360bcb11a5df08b494b995287074d0d744ec562c17"
+  end
+
+  # icons
+  ICONS_INFO.each do |icon, iconsha|
+    option "with-#{icon}", "Using Emacs icon: #{icon}"
+    next if build.without? icon
+
+    resource icon do
+      url (@@urlResolver.icon_url icon), using: CopyDownloadStrategy
+      sha256 iconsha
+    end
+  end
 
   if build.with? "no-title-bars"
     patch do

--- a/patches/emacs-mac-31-multi-tty.diff
+++ b/patches/emacs-mac-31-multi-tty.diff
@@ -1,0 +1,52 @@
+diff --git a/lisp/server.el b/lisp/server.el
+index c7165bbc884..26ea5ce0777 100644
+--- a/lisp/server.el
++++ b/lisp/server.el
+@@ -1357,7 +1357,6 @@ server--process-filter-1
+                  (when (or (and (eq system-type 'windows-nt)
+                                 (or (daemonp)
+                                     (eq window-system 'w32)))
+-                           (eq window-system 'mac)
+                            ;; Client runs on Windows, but the server
+                            ;; runs on a Posix host.
+                            (equal tty-name "CONOUT$"))
+diff --git a/src/frame.c b/src/frame.c
+index 67a6e2ac079..22ed326381e 100644
+--- a/src/frame.c
++++ b/src/frame.c
+@@ -1771,12 +1771,8 @@ affects all frames on the same terminal device.  */)
+     emacs_abort ();
+ #else /* not MSDOS */
+ 
+-#ifdef defined WINDOWSNT || defined HAVE_MACGUI /* This should work now! */
+-  if (!FRAME_TERMCAP_P (sf)
+-#ifdef HAVE_MACGUI
+-      && sf->output_method != output_initial
+-#endif
+-      )
++#ifdef WINDOWSNT /* This should work now! */
++  if (!FRAME_TERMCAP_P (sf))
+     error ("Not using an ASCII terminal now; cannot make a new ASCII frame");
+ #endif
+ #endif /* not MSDOS */
+diff --git a/src/macterm.c b/src/macterm.c
+index 087b38c0674..452d0be6e75 100644
+--- a/src/macterm.c
++++ b/src/macterm.c
+@@ -2978,6 +2978,7 @@ mac_mouse_position (struct frame **fp, int insist, Lisp_Object *bar_window,
+ {
+   struct frame *f1;
+   struct mac_display_info *dpyinfo = FRAME_DISPLAY_INFO (*fp);
++  struct frame *sf = SELECTED_FRAME ();
+   bool return_no_frame_flag = false;
+ 
+   block_input ();
+@@ -3017,7 +3018,7 @@ mac_mouse_position (struct frame **fp, int insist, Lisp_Object *bar_window,
+ 	f1 = XFRAME (mac_event_frame ());
+     }
+ 
+-  if (f1)
++  if (f1 && !FRAME_TERMCAP_P (f1))
+     {
+       /* Ok, we found a frame.  Store all the values.
+ 	 last_mouse_glyph is a rectangle used to reduce the generation


### PR DESCRIPTION
The new patch is a copy of emacs-mac-29.2-rc-1-multi-tty.diff with update in src/frame.c to use FRAME_TERMCAP_P macro
instead of sf->output_method.  This follows changes in cc4c8e6e9f41bc07cb3047e4ecc52ccfeaac0c75.

fixes: #411