### PR TITLE
Fix deprecated `depends_on macos:` syntax

### DIFF
--- a/Casks/emacs-mac-28-spacemacs-icon.rb
+++ b/Casks/emacs-mac-28-spacemacs-icon.rb
@@ -2,11 +2,11 @@ cask 'emacs-mac-28-spacemacs-icon' do
   version 'emacs-28.3-rc1-mac-9.2'
 
   if Hardware::CPU.intel?
-    depends_on macos: ">= :ventura" # macOS 13
+    depends_on macos: :ventura # macOS 13
     sha256 '368841421adff600c3941fcd94bd32532a005ce65ec56bf2834df97d73f28b85'
     url 'https://github.com/railwaycat/homebrew-emacsmacport/releases/download/emacs-28.3-rc1-mac-9.2/emacs-28.3-rc1-mac-9.2-x86_64-13.7.6-spacemacs-icon.zip', verified: "github.com/railwaycat/homebrew-emacsmacport"
   else # Apple Silicon
-    depends_on macos: ">= :sonoma" # macOS 14
+    depends_on macos: :sonoma # macOS 14
 
     if MacOS.version >= :sequoia # macOS 15
       # for macOS is or newer than 15

--- a/Casks/emacs-mac-28.rb
+++ b/Casks/emacs-mac-28.rb
@@ -2,11 +2,11 @@ cask 'emacs-mac-28' do
   version 'emacs-28.3-rc1-mac-9.2'
 
   if Hardware::CPU.intel?
-    depends_on macos: ">= :ventura" # macOS 13
+    depends_on macos: :ventura # macOS 13
     sha256 '1ba349eb63edb0345c9514b76b1460023d0b59c118459f9f5e577be523d44d89'
     url 'https://github.com/railwaycat/homebrew-emacsmacport/releases/download/emacs-28.3-rc1-mac-9.2/emacs-28.3-rc1-mac-9.2-x86_64-13.7.6.zip', verified: "github.com/railwaycat/homebrew-emacsmacport"
   else # Apple Silicon
-    depends_on macos: ">= :sonoma" # macOS 14
+    depends_on macos: :sonoma # macOS 14
 
     if MacOS.version >= :sequoia # macOS 15
       # for macOS is or newer than 15

--- a/Casks/emacs-mac-spacemacs-icon.rb
+++ b/Casks/emacs-mac-spacemacs-icon.rb
@@ -2,12 +2,12 @@ cask 'emacs-mac-spacemacs-icon' do
   version 'emacs-29.4-mac-10.1'
 
   if Hardware::CPU.intel?
-    depends_on macos: ">= :ventura"
+    depends_on macos: :ventura
 
     sha256 '79f1406d98c341114b90be5eecca93a69d6a07b87533351b0b8fb792906b33a4'
     url 'https://github.com/railwaycat/homebrew-emacsmacport/releases/download/emacs-29.4-mac-10.1/emacs-29.4-mac-10.1-x86_64-13.7.6-spacemacs-icon.zip', verified: "github.com/railwaycat/homebrew-emacsmacport"
   else # Apple Silicon
-    depends_on macos: ">= :ventura"
+    depends_on macos: :ventura
 
     if MacOS.version >= :sequoia # macOS 15
       # for macOS is or newer than 15

--- a/Casks/emacs-mac.rb
+++ b/Casks/emacs-mac.rb
@@ -2,12 +2,12 @@ cask 'emacs-mac' do
   version 'emacs-29.4-mac-10.1'
 
   if Hardware::CPU.intel?
-    depends_on macos: ">= :ventura"
+    depends_on macos: :ventura
 
     sha256 '412516bec8d5561163c868874b452c7275aa903617df252cf6a287289b6d7fe3'
     url 'https://github.com/railwaycat/homebrew-emacsmacport/releases/download/emacs-29.4-mac-10.1/emacs-29.4-mac-10.1-x86_64-13.7.6.zip', verified: "github.com/railwaycat/homebrew-emacsmacport"
   else # Apple Silicon
-    depends_on macos: ">= :ventura"
+    depends_on macos: :ventura
 
     if MacOS.version >= :sequoia # macOS 15
       # for macOS is or newer than 15


### PR DESCRIPTION
This PR fixes a Homebrew deprecation warning regarding the `depends_on macos:` stanza syntax in `emacs-mac*.rb`. 

Recent [Homebrew updates](https://docs.brew.sh/Formula-Cookbook#specifying-other-formulae-as-dependencies) deprecated the string comparison format (e.g., `">= :ventura"`). This changes it to the currently accepted symbol format (`:ventura`), which implicitly means "macOS Ventura or newer".

Fixes #416 